### PR TITLE
log performance events

### DIFF
--- a/src/plugins/data/public/search/fetch/handle_response.tsx
+++ b/src/plugins/data/public/search/fetch/handle_response.tsx
@@ -38,6 +38,7 @@ import { getNotifications } from '../../services';
 import { SearchRequest } from '..';
 
 export function handleResponse(request: SearchRequest, response: SearchResponse<any>) {
+  console.log('EVENT: data received');
   if (response.timed_out) {
     getNotifications().toasts.addWarning({
       title: i18n.translate('data.search.searchSource.fetch.requestTimedOutNotificationMessage', {

--- a/src/plugins/data/public/search/search_service.ts
+++ b/src/plugins/data/public/search/search_service.ts
@@ -133,6 +133,7 @@ export class SearchService implements Plugin<ISearchSetup, ISearchStart> {
     { fieldFormats, indexPatterns }: SearchServiceStartDependencies
   ): ISearchStart {
     const search = ((request, options) => {
+      console.log('EVENT: data requested');
       return this.searchInterceptor.search(request, options);
     }) as ISearchGeneric;
 

--- a/src/plugins/data/server/search/opensearch_search/opensearch_search_strategy.ts
+++ b/src/plugins/data/server/search/opensearch_search/opensearch_search_strategy.ts
@@ -89,6 +89,7 @@ export const opensearchSearchStrategyProvider = (
         const promise = shimAbortSignal(client.search(params), options?.abortSignal);
 
         const { body: rawResponse } = (await promise) as ApiResponse<SearchResponse<any>>;
+        console.log('SERVER EVENT: data received from Elasticsearch');
 
         if (usage) usage.trackSuccess(rawResponse.took);
 

--- a/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
+++ b/src/plugins/visualizations/public/embeddable/visualize_embeddable.ts
@@ -296,6 +296,7 @@ export class VisualizeEmbeddable
   };
 
   onContainerRender = () => {
+    console.log('EVENT: render complete');
     this.renderComplete.dispatchComplete();
     this.updateOutput({ loading: false, error: undefined });
   };


### PR DESCRIPTION
Adds some events to benchmark performance

**Client-side**
- visualization data requested by client
- visualization data received from server
- chart finished drawing

**Server**
- visualization data received from OpenSearch